### PR TITLE
fix: Build with args using empty entrypoint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ pipeline {
             steps {
                 sh 'mkdir /tmp/ready'
                 sh 'ls -hal /tmp'
-                sh "cat /tmp/ready"
+                echo "test" > test
+                sh "cat /tmp/ready/test"
             }
         }
     }


### PR DESCRIPTION
Changes include the following:

- Add test file to directory

Signed-off-by: James Gregg <james.r.gregg@intel.com>