### PR TITLE
Update base image to use python:3.9-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:latest
+FROM python:3.9-alpine
 COPY entry.sh /opt/bin/


### PR DESCRIPTION
Update to python:3.9-alpine
Signed-off-by: James Gregg <james.r.gregg@intel.com>